### PR TITLE
Function return column indirection problem

### DIFF
--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -314,7 +314,7 @@ class PgQuery
       if node['indirection']
         array_indirection = node['indirection'].select { |a| a.key?(A_INDICES) }
       end
-      output << if node['arg'].key?(FUNC_CALL) || node['arg'].key?(A_EXPR) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
+      output << if node['arg'].key?(FUNC_CALL) || node['arg'].key?(COLUMN_REF) || node['arg'].key?(A_EXPR) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
                   "(#{arg})."
                 else
                   arg

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -314,7 +314,7 @@ class PgQuery
       if node['indirection']
         array_indirection = node['indirection'].select { |a| a.key?(A_INDICES) }
       end
-      output << if node['arg'].key?(FUNC_CALL) || node['arg'].key?(COLUMN_REF) || node['arg'].key?(A_EXPR) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
+      output << if node['arg'].key?(FUNC_CALL) || (node['arg'].key?(COLUMN_REF) && array_indirection.count.zero?) || node['arg'].key?(A_EXPR) || (node['arg'].key?(SUB_LINK) && array_indirection.count.zero?)
                   "(#{arg})."
                 else
                   arg

--- a/lib/pg_query/deparse.rb
+++ b/lib/pg_query/deparse.rb
@@ -307,7 +307,7 @@ class PgQuery
       '*'
     end
 
-    def deparse_a_indirection(node)
+    def deparse_a_indirection(node) # rubocop:disable Metrics/CyclomaticComplexity
       output = []
       arg = deparse_item(node['arg'])
       array_indirection = []

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -392,6 +392,12 @@ describe PgQuery::Deparse do
         it { is_expected.to eq query }
       end
 
+      context 'indirection function with star' do
+        let(:query) { 'SELECT ("a").*, ("b").* FROM (SELECT sp_function("b"."col") as a FROM "tb_other") as b' }
+
+        it { is_expected.to eq query }
+      end
+
       context 'NOT' do
         let(:query) { 'SELECT * FROM "x" WHERE NOT "y"' }
 

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -393,7 +393,7 @@ describe PgQuery::Deparse do
       end
 
       context 'indirection function with star' do
-        let(:query) { 'SELECT ("a").*, ("b").* FROM (SELECT sp_function("b"."col") as a FROM "tb_other") b' }
+        let(:query) { 'SELECT ("a").*, ("b").* FROM (SELECT sp_function("b"."col") AS a FROM "tb_other") b' }
 
         it { is_expected.to eq query }
       end

--- a/spec/lib/pg_query/deparse_spec.rb
+++ b/spec/lib/pg_query/deparse_spec.rb
@@ -393,7 +393,7 @@ describe PgQuery::Deparse do
       end
 
       context 'indirection function with star' do
-        let(:query) { 'SELECT ("a").*, ("b").* FROM (SELECT sp_function("b"."col") as a FROM "tb_other") as b' }
+        let(:query) { 'SELECT ("a").*, ("b").* FROM (SELECT sp_function("b"."col") as a FROM "tb_other") b' }
 
         it { is_expected.to eq query }
       end


### PR DESCRIPTION
SQL: SELECT ("a").*, ("b").* FROM (select sp_function("b"."col") as a FROM "tb_other") b

Expected: SELECT ("a").*, ("b").* FROM (select sp_function("b"."col") as a FROM "tb_other") b

Got: SELECT "a"*, "b"* FROM (SELECT sp_function("b"."col") AS a FROM "tb_other") b