### PR TITLE
[1.x] Add COALESCE argument names to #filter_columns

### DIFF
--- a/lib/pg_query/filter_columns.rb
+++ b/lib/pg_query/filter_columns.rb
@@ -62,6 +62,8 @@ class PgQuery
           condition_items += next_item[BOOL_EXPR]['args']
         elsif next_item[ROW_EXPR]
           condition_items += next_item[ROW_EXPR]['args']
+        elsif next_item[COALESCE_EXPR]
+          condition_items += next_item[COALESCE_EXPR]['args']
         elsif next_item[COLUMN_REF]
           column, table = next_item[COLUMN_REF]['fields'].map { |f| f['String']['str'] }.reverse
           filter_columns << [@aliases[table] || table, column]

--- a/spec/lib/filter_columns_spec.rb
+++ b/spec/lib/filter_columns_spec.rb
@@ -22,4 +22,8 @@ describe PgQuery, '#filter_columns' do
   it 'recognizes boolean tests' do
     expect(filter_columns('SELECT * FROM x WHERE x.y IS TRUE AND x.z IS NOT FALSE')).to eq [['x', 'y'], ['x', 'z']]
   end
+
+  it 'finds COALESCE argument names' do
+    expect(filter_columns('SELECT * FROM x WHERE x.y = COALESCE(z.a, z.b)')).to eq [['x', 'y'], ['z', 'a'], ['z', 'b']]
+  end
 end


### PR DESCRIPTION
This PR adds an already-parsed expression type `COALESCE_EXPR` into `#filter_columns`.

