### PR TITLE
Support --with-pg_query-workdir to specific workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ gem install pg_query
 
 Due to compiling parts of PostgreSQL, installation might take a while on slower systems. Expect up to 5 minutes.
 
+For some reason download `libpg_query-xx.tar.gz` from https://codeload.github.com/lfittl/libpg_query/tar.gz/ is very slow(Download from China),
+we can pre-download this file to `/tmp/`, then use `--with-pg_query-workdir=/tmp/` to compile it without downloading.
+
+```
+gem install pg_query --with-pg_query-workdir=/tmp/
+```
+
 ## Usage
 
 ### Parsing a query

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem install pg_query
 
 Due to compiling parts of PostgreSQL, installation might take a while on slower systems. Expect up to 5 minutes.
 
-For some reason download `libpg_query-xx.tar.gz` from https://codeload.github.com/lfittl/libpg_query/tar.gz/ is very slow(Download from China),
+For some reason download `libpg_query-xx.tar.gz` from https://codeload.github.com/lfittl/libpg_query/tar.gz/ is very slow when downloading from China.
 we can pre-download this file to `/tmp/`, then use `--with-pg_query-workdir=/tmp/` to compile it without downloading.
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem install pg_query
 Due to compiling parts of PostgreSQL, installation might take a while on slower systems. Expect up to 5 minutes.
 
 For some reason download `libpg_query-xx.tar.gz` from https://codeload.github.com/lfittl/libpg_query/tar.gz/ is very slow when downloading from China.
-we can pre-download this file to `/tmp/`, then use `--with-pg_query-workdir=/tmp/` to compile it without downloading.
+We can pre-download this file to `/tmp/`, then use `--with-pg_query-workdir=/tmp/` to compile it without downloading.
 
 ```
 gem install pg_query --with-pg_query-workdir=/tmp/

--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -23,7 +23,7 @@ unless File.exist?(filename)
   checksum = Digest::SHA256.hexdigest(File.read(filename))
 
   if checksum != LIB_PG_QUERY_SHA256SUM
-    raise "SHA256 of #{filename} does not match: got #{checksum}, expected #{expected_sha256}"
+    raise "SHA256 of #{filename} does not match: got #{checksum}, expected #{LIB_PG_QUERY_SHA256SUM}"
   end
 end
 

--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -7,7 +7,7 @@ require 'open-uri'
 LIB_PG_QUERY_TAG = '10-1.0.4'.freeze
 LIB_PG_QUERY_SHA256SUM = '88cc90296e5fcaaebd0b360c46698b7c5badddf86f120e249ef682a820d41338'.freeze
 
-workdir = Dir.pwd
+workdir = File.expand_path(with_config('pg_query-workdir', Dir.pwd))
 libdir = File.join(workdir, 'libpg_query-' + LIB_PG_QUERY_TAG)
 gemdir = File.join(__dir__, '../..')
 libfile = libdir + '/libpg_query.a'
@@ -28,7 +28,7 @@ unless File.exist?(filename)
 end
 
 unless Dir.exist?(libdir)
-  system("tar -xzf #{filename}") || raise('ERROR')
+  system("tar -xzf #{filename} -C #{workdir}") || raise('ERROR')
 end
 
 unless Dir.exist?(libfile)


### PR DESCRIPTION
For some reason download `libpg_query-xx.tar.gz` from https://codeload.github.com/lfittl/libpg_query/tar.gz/ is very slow(Download from China),
we can pre-download this file to `/tmp/`, then use `--with-pg_query-workdir=/tmp/` to compile it without downloading.

```
gem install pg_query --with-pg_query-workdir=/tmp/
```