### PR TITLE
[2.0] Add COALESCE argument names to #filter_columns

### DIFF
--- a/lib/pg_query/filter_columns.rb
+++ b/lib/pg_query/filter_columns.rb
@@ -62,6 +62,8 @@ module PgQuery
             condition_items << next_item.a_expr.rexpr if next_item.a_expr.rexpr
           when :bool_expr
             condition_items += next_item.bool_expr.args
+          when :coalesce_expr
+            condition_items += next_item.coalesce_expr.args
           when :row_expr
             condition_items += next_item.row_expr.args
           when :column_ref

--- a/spec/lib/filter_columns_spec.rb
+++ b/spec/lib/filter_columns_spec.rb
@@ -22,4 +22,8 @@ describe PgQuery, '#filter_columns' do
   it 'recognizes boolean tests' do
     expect(filter_columns('SELECT * FROM x WHERE x.y IS TRUE AND x.z IS NOT FALSE')).to eq [['x', 'y'], ['x', 'z']]
   end
+
+  it 'finds COALESCE argument names' do
+    expect(filter_columns('SELECT * FROM x WHERE x.y = COALESCE(z.a, z.b)')).to eq [['x', 'y'], ['z', 'a'], ['z', 'b']]
+  end
 end


### PR DESCRIPTION
This is the same PR as #189 but for 2.x.