### PR TITLE
Use Rake's clean task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'bundler/gem_tasks'
+require 'rake/clean'
 require 'rake/extensiontask'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
@@ -20,11 +21,9 @@ task default: %i[spec lint]
 task test: :spec
 task lint: :rubocop
 
-task :clean do
-  FileUtils.rm_rf File.join(__dir__, 'tmp/')
-  FileUtils.rm_f Dir.glob(File.join(__dir__, 'ext/pg_query/*.o'))
-  FileUtils.rm_f File.join(__dir__, 'lib/pg_query/pg_query.bundle')
-end
+CLEAN << 'tmp/**/*'
+CLEAN << 'ext/pg_query/*.o'
+CLEAN << 'lib/pg_query/pg_query.bundle'
 
 task :update_source do
   workdir = File.join(__dir__, 'tmp')


### PR DESCRIPTION
This PR introduces Rake's `CLEAN` and `CLOBBER` FileList objects, and the `:clean` and `:clobber` tasks from there.

## Details

The `FileList#<<` operator accepts many kinds of pattern, and resolves them to useful FileList elements.

Rake separates clean from clobber, but the project has not currently done so, so I will leave it as it is.

See `rake/clean` for more details: https://github.com/ruby/rake/blob/master/lib/rake/clean.rb

And, Avdi's blog post about it: https://avdi.codes/rake-part-6-clean-and-clobber/