### PR TITLE
Extconf: Fix object paths builder

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -3,8 +3,9 @@
 require 'digest'
 require 'mkmf'
 require 'open-uri'
+require 'pathname'
 
-$objs = Dir.glob(File.join(__dir__, '*.c')).map { |f| f.gsub('.c', '.o') }
+$objs = Dir.glob(File.join(__dir__, '*.c')).map { |f| Pathname.new(f).sub_ext('.o').to_s }
 
 $CFLAGS << " -I#{File.join(__dir__, 'include')} -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-protector -Wno-unused-function -Wno-unused-variable -g"
 


### PR DESCRIPTION
C Path: '/Users/tam.chau/.rvm/gems/ruby-2.7.2/gems/pg_query-2.0.1/ext/pg_query/src_backend_tcop_postgres.c'

Expected: '/Users/tam.chau/.rvm/gems/ruby-2.7.2/gems/pg_query-2.0.1/ext/pg_query/src_backend_tcop_postgres.o'

Got: '/Users/tam.ohau/.rvm/gems/ruby-2.7.2/gems/pg_query-2.0.1/ext/pg_query/src_backend_tcop_postgres.o'