### PR TITLE
Fix rare crashes in truncate function due to deparse failures

### DIFF
--- a/lib/pg_query/truncate.rb
+++ b/lib/pg_query/truncate.rb
@@ -51,7 +51,7 @@ module PgQuery
 
     private
 
-    def find_possible_truncations
+    def find_possible_truncations # rubocop:disable Metrics/CyclomaticComplexity
       truncations = []
 
       treewalker! @tree do |node, k, v, location|
@@ -62,8 +62,8 @@ module PgQuery
           truncations << PossibleTruncation.new(location, :target_list, length, true)
         when :where_clause
           next unless node.is_a?(PgQuery::SelectStmt) || node.is_a?(PgQuery::UpdateStmt) || node.is_a?(PgQuery::DeleteStmt) ||
-            node.is_a?(PgQuery::CopyStmt) || node.is_a?(PgQuery::IndexStmt) || node.is_a?(PgQuery::RuleStmt) ||
-            node.is_a?(PgQuery::InferClause) || node.is_a?(PgQuery::OnConflictClause)
+                      node.is_a?(PgQuery::CopyStmt) || node.is_a?(PgQuery::IndexStmt) || node.is_a?(PgQuery::RuleStmt) ||
+                      node.is_a?(PgQuery::InferClause) || node.is_a?(PgQuery::OnConflictClause)
 
           length = PgQuery.deparse_expr(v).size
           truncations << PossibleTruncation.new(location, :where_clause, length, false)

--- a/spec/lib/truncate_spec.rb
+++ b/spec/lib/truncate_spec.rb
@@ -30,4 +30,19 @@ describe PgQuery, '#truncate' do
     query = 'SELECT CASE WHEN $2.typtype = ? THEN $2.typtypmod ELSE $1.atttypmod END'
     expect(described_class.parse(query).truncate(50)).to eq 'SELECT ...'
   end
+
+  it 'handles UPDATE target list' do
+    query = 'UPDATE x SET a = 1, c = 2, e = \'str\''
+    expect(described_class.parse(query).truncate(30)).to eq 'UPDATE x SET ... = ...'
+  end
+
+  it 'handles ON CONFLICT target list' do
+    query = 'INSERT INTO y(a) VALUES(1) ON CONFLICT DO UPDATE SET a = 123456789'
+    expect(described_class.parse(query).truncate(65)).to eq 'INSERT INTO y (a) VALUES (1) ON CONFLICT DO UPDATE SET ... = ...'
+  end
+
+  it 'handles GRANT access privileges' do
+    query = 'GRANT SELECT (abc, def, ghj) ON TABLE t1 TO r1'
+    expect(described_class.parse(query).truncate(35)).to eq 'GRANT select (abc, def, ghj) ON ...'
+  end
 end


### PR DESCRIPTION
The truncation function wasn't careful about which node types had their
fields replaced, and this would sometimes lead to invalid parse trees
being generated that then led to a crash in the deparser.