### PR TITLE
Update google-protobuf to 3.17.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     pg_query (2.0.3)
-      google-protobuf (~> 3.15.5)
+      google-protobuf (~> 3.17.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
     diff-lcs (1.3)
-    google-protobuf (3.15.7)
+    google-protobuf (3.17.1)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '0.49.1'
   s.add_development_dependency 'rubocop-rspec', '1.15.1'
-  s.add_dependency 'google-protobuf', '~> 3.15.5'
+  s.add_dependency 'google-protobuf', '~> 3.17.1'
 end


### PR DESCRIPTION
google-protobuf 3.15.x has a bug that causes a seg fault in Ruby under
certain conditions (https://github.com/protocolbuffers/protobuf/pull/8639). Use
google-protobuf 3.17.1 instead.