### PR TITLE
Relax google-protobuf dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pg_query (2.0.3)
-      google-protobuf (~> 3.17.1)
+      google-protobuf (>= 3.17.1)
 
 GEM
   remote: https://rubygems.org/

--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '0.49.1'
   s.add_development_dependency 'rubocop-rspec', '1.15.1'
-  s.add_dependency 'google-protobuf', '~> 3.17.1'
+  s.add_dependency 'google-protobuf', '>= 3.17.1'
 end


### PR DESCRIPTION
Applications depend on upgrading google-protobuf regularly.
It may not be necessary to tie this version so strictly.