### PR TITLE
Extconf: Add library include path using $INCFLAGS, list it first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
     from the Proto3 definition (instead of the differently formatted Protobuf field names)
 * Rakefile: Fix "rake clean" by using CLEAN.include instead of CLEAN.<<
 * Find tables inside COALESCE/MIN/MAX functions, UPDATE FROM list
+* Extconf: Add library include path using $INCFLAGS, list it first
+  - This ensures any system installed libpg_query gets considered after
+    the bundled libpg_query, avoiding errors where the wrong header files
+    are used.
 
 
 ## 2.0.3     2021-04-05

--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -7,7 +7,9 @@ require 'pathname'
 
 $objs = Dir.glob(File.join(__dir__, '*.c')).map { |f| Pathname.new(f).sub_ext('.o').to_s }
 
-$CFLAGS << " -I#{File.join(__dir__, 'include')} -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-protector -Wno-unused-function -Wno-unused-variable -g"
+$CFLAGS << " -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-protector -Wno-unused-function -Wno-unused-variable -g"
+
+$INCFLAGS = "-I#{File.join(__dir__, 'include')} " + $INCFLAGS
 
 SYMFILE = File.join(__dir__, 'pg_query_ruby.sym')
 if RUBY_PLATFORM =~ /darwin/


### PR DESCRIPTION
This ensures any system installed libpg_query gets considered after
the bundled libpg_query, avoiding errors where the wrong header files
are used.

Per report in https://github.com/pganalyze/pg_query/issues/215 and
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=256741