### PR TITLE
Rakefile: Fix "rake clean" by using CLEAN.include instead of CLEAN.<<

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Note you may see a breaking change if you were using `PgQuery::ParseResult.encode_json`
     to map the protobuf result to JSON, since this now respects the intended JSON names
     from the Proto3 definition (instead of the differently formatted Protobuf field names)
+* Rakefile: Fix "rake clean" by using CLEAN.include instead of CLEAN.<<
 
 
 ## 2.0.3     2021-04-05

--- a/Rakefile
+++ b/Rakefile
@@ -21,9 +21,9 @@ task default: %i[spec lint]
 task test: :spec
 task lint: :rubocop
 
-CLEAN << 'tmp/**/*'
-CLEAN << 'ext/pg_query/*.o'
-CLEAN << 'lib/pg_query/pg_query.bundle'
+CLEAN.include 'tmp/**/*'
+CLEAN.include 'ext/pg_query/*.o'
+CLEAN.include 'lib/pg_query/pg_query.bundle'
 
 task :update_source do
   workdir = File.join(__dir__, 'tmp')


### PR DESCRIPTION
Previously this was not actually cleaning the files correctly, since it
didn't process the patterns as wildcards, but rather literal file names.