### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -11,6 +11,8 @@ $CFLAGS << " -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-protector -Wno-unuse
 
 $INCFLAGS = "-I#{File.join(__dir__, 'include')} " + $INCFLAGS
 
+have_func('strchrnul')
+
 SYMFILE = File.join(__dir__, 'pg_query_ruby.sym')
 if RUBY_PLATFORM =~ /darwin/
   $DLDFLAGS << " -Wl,-exported_symbols_list #{SYMFILE}" unless defined?(::Rubinius)

--- a/ext/pg_query/pg_query_ruby.sym
+++ b/ext/pg_query/pg_query_ruby.sym
@@ -1,1 +1,2 @@
 _Init_pg_query
+Init_pg_query


### PR DESCRIPTION
FreeBSD has strchrnul, detect it in the configuration.

Add the ELF symbol name to the exported symbol list. bfd exports all symbols if it can't find any symbols in the export list. lld (the FreeBSD default linker) exports nothing.