### PR TITLE
Mark Postgres methods as visibility hidden, to avoid bloating dynamic symbol table

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -7,7 +7,7 @@ require 'pathname'
 
 $objs = Dir.glob(File.join(__dir__, '*.c')).map { |f| Pathname.new(f).sub_ext('.o').to_s }
 
-$CFLAGS << " -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-protector -Wno-unused-function -Wno-unused-variable -g"
+$CFLAGS << " -fvisibility=hidden -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-protector -Wno-unused-function -Wno-unused-variable -Wno-clobbered -Wno-sign-compare -Wno-discarded-qualifiers -g"
 
 $INCFLAGS = "-I#{File.join(__dir__, 'include')} " + $INCFLAGS
 

--- a/ext/pg_query/pg_query_ruby.c
+++ b/ext/pg_query/pg_query_ruby.c
@@ -14,7 +14,7 @@ VALUE pg_query_ruby_fingerprint(VALUE self, VALUE input);
 VALUE pg_query_ruby_scan(VALUE self, VALUE input);
 VALUE pg_query_ruby_hash_xxh3_64(VALUE self, VALUE input, VALUE seed);
 
-void Init_pg_query(void)
+__attribute__((visibility ("default"))) void Init_pg_query(void)
 {
 	VALUE cPgQuery;
 


### PR DESCRIPTION
This is required on ELF platforms (i.e. Linux, etc) to avoid including all global
symbols in the shared library's symbol table, bloating the size, and causing
potential conflicts with other C libraries using the same symbol names.