### PR TITLE
Correctly find nested tables in a subselect in a join condition

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -118,6 +118,20 @@ module PgQuery
             subselect_items.concat(statement.select_stmt.group_clause.to_ary)
             subselect_items << statement.select_stmt.having_clause if statement.select_stmt.having_clause
 
+            if statement.select_stmt.from_clause
+              join_expr_quals = []
+              statement.select_stmt.from_clause.each do |from_clause|
+                next unless from_clause.join_expr
+                curr_join_expr = from_clause.join_expr
+                while curr_join_expr
+                  join_expr_quals << curr_join_expr.quals
+                  curr_join_expr = curr_join_expr.larg.join_expr
+                end
+              end
+
+              subselect_items.concat(join_expr_quals)
+            end
+
             case statement.select_stmt.op
             when :SETOP_NONE
               (statement.select_stmt.from_clause || []).each do |item|

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -118,24 +118,22 @@ module PgQuery
             subselect_items.concat(statement.select_stmt.group_clause.to_ary)
             subselect_items << statement.select_stmt.having_clause if statement.select_stmt.having_clause
 
-            if statement.select_stmt.from_clause
-              join_expr_quals = []
-              statement.select_stmt.from_clause.each do |from_clause|
-                next unless from_clause.join_expr
-                curr_join_expr = from_clause.join_expr
-                while curr_join_expr
-                  join_expr_quals << curr_join_expr.quals
-                  curr_join_expr = curr_join_expr.larg.join_expr
-                end
-              end
-
-              subselect_items.concat(join_expr_quals)
-            end
-
             case statement.select_stmt.op
             when :SETOP_NONE
               (statement.select_stmt.from_clause || []).each do |item|
                 from_clause_items << { item: item, type: :select }
+
+                join_expr_quals = []
+                statement.select_stmt.from_clause.each do |from_clause|
+                  next unless from_clause.join_expr
+                  curr_join_expr = from_clause.join_expr
+                  while curr_join_expr
+                    join_expr_quals << curr_join_expr.quals
+                    curr_join_expr = curr_join_expr.larg.join_expr
+                  end
+                end
+
+                subselect_items.concat(join_expr_quals)
               end
             when :SETOP_UNION
               statements << PgQuery::Node.new(select_stmt: statement.select_stmt.larg) if statement.select_stmt.larg

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1400,6 +1400,33 @@ $BODY$
     expect(query.tables).to eq ['foo', 'bar']
   end
 
+  it 'it correctly finds nested tables in a subselect in a join condition' do
+    query = described_class.parse(<<~SQL)
+      SELECT *
+      FROM foo
+      INNER JOIN join_a
+        ON foo.id = join_a.id AND
+        join_a.id IN (
+          SELECT id
+          FROM sub_a
+          INNER JOIN sub_b
+            ON sub_a.id = sub_b.id
+              AND sub_b.id IN (
+                SELECT id
+                FROM sub_c
+                INNER JOIN sub_d ON sub_c.id IN (SELECT id from sub_e)
+              )
+        )
+      INNER JOIN join_b
+        ON foo.id = join_b.id AND
+        join_b.id IN (
+          SELECT id FROM sub_f
+        )
+    SQL
+    expect(query.warnings).to eq []
+    expect(query.tables).to match_array ['foo', 'join_a', 'join_b', 'sub_a', 'sub_b', 'sub_c', 'sub_d', 'sub_e', 'sub_f']
+  end
+
   it 'does not list CTEs as tables after a union select' do
     query = described_class.parse(<<-SQL)
       with cte_a as (

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1400,8 +1400,8 @@ $BODY$
     expect(query.tables).to eq ['foo', 'bar']
   end
 
-  it 'it correctly finds nested tables in a subselect in a join condition' do
-    query = described_class.parse(<<~SQL)
+  it 'correctly finds nested tables in a subselect in a join condition' do
+    query = described_class.parse(<<-SQL)
       SELECT *
       FROM foo
       INNER JOIN join_a


### PR DESCRIPTION
Expected behavior:
```
PgQuery.parse('SELECT * FROM foo JOIN bar ON bar.id IN (SELECT id from baz)').tables == ['foo', 'bar', 'baz']
```

On `main`, `baz` isn't being found. On my branch it is, as well as tables that are nested further inside of a join condition (see spec for a query with more nested join conditions and subqueries). 