### PR TITLE
load_objects: Add missing to_ary in subselect List node handling

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -237,7 +237,7 @@ module PgQuery
         if next_item
           case next_item.node
           when :list
-            subselect_items += next_item.list.items
+            subselect_items += next_item.list.items.to_ary
           when :a_expr
             %w[lexpr rexpr].each do |side|
               elem = next_item.a_expr.public_send(side)
@@ -273,7 +273,7 @@ module PgQuery
           when :join_expr
             from_clause_items << { item: next_item[:item].join_expr.larg, type: next_item[:type] }
             from_clause_items << { item: next_item[:item].join_expr.rarg, type: next_item[:type] }
-            subselect_items.concat << next_item[:item].join_expr.quals
+            subselect_items << next_item[:item].join_expr.quals
           when :row_expr
             from_clause_items += next_item[:item].row_expr.args.map { |a| { item: a, type: next_item[:type] } }
           when :range_var


### PR DESCRIPTION
This also adjusts the change from 627ef49
slightly to remove an unnecessary concat.