### PR TITLE
PgQuery.parse: Support complex queries with deeply nested ASTs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
   specs:
     ast (2.4.1)
     diff-lcs (1.3)
-    google-protobuf (3.19.4)
+    google-protobuf (3.20.0)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -3,7 +3,13 @@ module PgQuery
     result, stderr = parse_protobuf(query)
 
     begin
-      result = PgQuery::ParseResult.decode(result)
+      result = if PgQuery::ParseResult.method(:decode).arity == 1
+                 PgQuery::ParseResult.decode(result)
+               elsif PgQuery::ParseResult.method(:decode).arity == -1
+                 PgQuery::ParseResult.decode(result, recursion_limit: 1_000)
+               else
+                 raise ArgumentError, 'Unsupported protobuf Ruby API'
+               end
     rescue Google::Protobuf::ParseError => e
       raise PgQuery::ParseError.new(format('Failed to parse tree: %s', e.message), __FILE__, __LINE__, -1)
     end


### PR DESCRIPTION
Depends on https://github.com/protocolbuffers/protobuf/pull/9218, until
that is merged this can only be used with a custom built protobuf gem.

Fixes #209