### PR TITLE
CI: add Ruby 3.1 to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake
+    - name: Tests
+      run: bundle exec rake test
+    - name: RuboCop
+      run: bundle exec rake lint
+      if: matrix.ruby != '3.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR extends the matrix.

On Ruby 3.1, we skip linting checks - when we have upgraded to a newer RuboCop, we can use that.

<img width="377" alt="bild" src="https://user-images.githubusercontent.com/211/166959374-990d5517-697d-461c-91fb-1f189501dcd6.png">
