### PR TITLE
Truncate improvements

### DIFF
--- a/spec/lib/truncate_spec.rb
+++ b/spec/lib/truncate_spec.rb
@@ -18,7 +18,7 @@ describe PgQuery, '#truncate' do
 
   it 'omits INSERT field list' do
     query = 'INSERT INTO "x" (a, b, c, d, e, f) VALUES (?)'
-    expect(described_class.parse(query).truncate(32)).to eq 'INSERT INTO x (...) VALUES (?)'
+    expect(described_class.parse(query).truncate(32)).to eq 'INSERT INTO x (...) VALUES (...)'
   end
 
   it 'omits comments' do
@@ -43,7 +43,8 @@ describe PgQuery, '#truncate' do
 
   it 'handles ON CONFLICT target list' do
     query = 'INSERT INTO y(a) VALUES(1) ON CONFLICT DO UPDATE SET a = 123456789'
-    expect(described_class.parse(query).truncate(65)).to eq 'INSERT INTO y (a) VALUES (1) ON CONFLICT DO UPDATE SET ... = ...'
+    expect(described_class.parse(query).truncate(66)).to eq 'INSERT INTO y (a) VALUES (...) ON CONFLICT DO UPDATE SET ... = ...'
+  end
   end
 
   it 'handles GRANT access privileges' do

--- a/spec/lib/truncate_spec.rb
+++ b/spec/lib/truncate_spec.rb
@@ -45,6 +45,10 @@ describe PgQuery, '#truncate' do
     query = 'INSERT INTO y(a) VALUES(1) ON CONFLICT DO UPDATE SET a = 123456789'
     expect(described_class.parse(query).truncate(66)).to eq 'INSERT INTO y (a) VALUES (...) ON CONFLICT DO UPDATE SET ... = ...'
   end
+
+  it 'handles complex ON CONFLICT target lists' do
+    query = 'INSERT INTO foo (a, b, c, d) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29) ON CONFLICT (id) DO UPDATE SET (a, b, c, d) = (excluded.a,excluded.b,excluded.c,case when foo.d = excluded.d then excluded.d end)'
+    expect(described_class.parse(query).truncate(100)).to eq 'INSERT INTO foo (a, b, c, d) VALUES (...) ON CONFLICT (id) DO UPDATE SET ... = ...'
   end
 
   it 'handles GRANT access privileges' do


### PR DESCRIPTION
```
Truncate: Simplify VALUES(...) lists
```

```
Truncate: Correctly handle UPDATE and ON CONFLICT target lists

These target list fields support MultiAssignRef nodes, which are not
supported in regular SELECT target lists - thus requiring special handling.
```