### PR TITLE
Gemfile.lock: Update protobuf to a recent version for testing of the gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
   specs:
     ast (2.4.1)
     diff-lcs (1.3)
-    google-protobuf (3.20.0)
+    google-protobuf (3.21.4)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)


### PR DESCRIPTION
This makes sure we avoid any ARM-based installation hazards present
on the previously locked version.