### PR TITLE
Drop `Init_pg_query` from exported symbol map

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -11,7 +11,13 @@ $CFLAGS << " -fvisibility=hidden -O3 -Wall -fno-strict-aliasing -fwrapv -fstack-
 
 $INCFLAGS = "-I#{File.join(__dir__, 'include')} " + $INCFLAGS
 
-SYMFILE = File.join(__dir__, 'pg_query_ruby.sym')
+SYMFILE =
+  if RUBY_PLATFORM =~ /freebsd/
+    File.join(__dir__, 'pg_query_ruby_freebsd.sym')
+  else
+    File.join(__dir__, 'pg_query_ruby.sym')
+  end
+
 if RUBY_PLATFORM =~ /darwin/
   $DLDFLAGS << " -Wl,-exported_symbols_list #{SYMFILE}" unless defined?(::Rubinius)
 else

--- a/ext/pg_query/pg_query_ruby_freebsd.sym
+++ b/ext/pg_query/pg_query_ruby_freebsd.sym
@@ -1,1 +1,2 @@
 _Init_pg_query
+Init_pg_query


### PR DESCRIPTION
`Init_pg_query` isn't actually exported, but `_Init_pg_query` is:

```
% nm pg_query_ruby.o | grep Init
0000000000000000 T _Init_pg_query
0000000000003b40 b _Init_pg_query.rb_intern_id_cache
```

A Ruby compiler compiled with XCode 14 without the flag `-undefined,dynamic_lookup` will see this error:

```
linking shared-object pg_query/pg_query.bundle
Undefined symbols for architecture arm64:
  "Init_pg_query", referenced from:
     -exported_symbol[s_list] command line option
     (maybe you meant: _Init_pg_query)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [pg_query.bundle] Error 1
```

In #222, FreeBSD needed `Init_pg_query`, so we uses a specific symbol map file for FreeBSD.

Closes #255