### PR TITLE
Expose recursive walk functionality via `walk!`

### DIFF
--- a/lib/pg_query/treewalker.rb
+++ b/lib/pg_query/treewalker.rb
@@ -1,5 +1,11 @@
 module PgQuery
   class ParserResult
+    def walk!
+      treewalker!(@tree) do |parent_node, parent_field, node, location|
+        yield(parent_node, parent_field, node, location)
+      end
+    end
+
     private
 
     def treewalker!(tree) # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
Fixes #267

This exposes the private `treewalker!` via a `walk!` interface. I opted to create a new `walk!` instead of making `treewalk!` public to avoid changing the signature on treewalker -- I could have made the tree argument have a default, but 🤷 I went this way. Happy to change it. 

I added a note to the README, though I'm a bit on the fence. In favor, documenting this seems good for the next person. But, I think my table rename example might be too trivial. In my own testing (see #267) I needed something that feels much larger than belongs there. If it's a common enough need, it could be pulled into the library directly, but that feels like a deeper feature to consider. 

In contrast, this is a pretty small patch.

Anyhow, that's a long winded explanation. 