### PR TITLE
Return relpersistence in #tables_with_details when parsing

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -312,7 +312,8 @@ module PgQuery
               location: rangevar.location,
               schemaname: (rangevar.schemaname unless rangevar.schemaname.empty?),
               relname: rangevar.relname,
-              inh: rangevar.inh
+              inh: rangevar.inh,
+              relpersistence: rangevar.relpersistence
             }
             @aliases[rangevar.alias.aliasname] = table if rangevar.alias
           when :range_subselect

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1791,7 +1791,7 @@ $BODY$
     SQL
     expect(query.tables).to eq(['foo'])
     expect(query.ddl_tables).to eq(['foo'])
-    expect(query.tables_with_details).to eq([
+    expect(query.tables_with_details).to eq [
       {
         inh: true,
         location: 24,
@@ -1801,6 +1801,6 @@ $BODY$
         schemaname: nil,
         type: :ddl
       }
-    ])
+    ]
   end
 end

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -809,7 +809,8 @@ describe PgQuery, '.parse' do
         name: "bigtable",
         relname: "bigtable",
         schemaname: nil,
-        type: :ddl
+        type: :ddl,
+        relpersistence: "p"
       },
       {
         inh: true,
@@ -817,7 +818,8 @@ describe PgQuery, '.parse' do
         name: "fattable",
         relname: "fattable",
         schemaname: nil,
-        type: :ddl
+        type: :ddl,
+        relpersistence: "p"
       }
     ]
     expect(query.tree.stmts.first).to eq(
@@ -1781,5 +1783,24 @@ $BODY$
       expect(query.ddl_tables).to eq([])
       expect(query.select_tables).to eq(['foo'])
     end
+  end
+
+  it 'parses CREATE TEMP TABLE' do
+    query = described_class.parse(<<-SQL)
+      CREATE TEMP TABLE foo AS SELECT 1;
+    SQL
+    expect(query.tables).to eq(['foo'])
+    expect(query.ddl_tables).to eq(['foo'])
+    expect(query.tables_with_details).to eq([
+      {
+        inh: true,
+        location: 24,
+        name: "foo",
+        relname: "foo",
+        relpersistence: "t",
+        schemaname: nil,
+        type: :ddl
+      }
+    ])
   end
 end


### PR DESCRIPTION
It would be very helpful for us to know when the parsed SQL is creating a temp table vs a permanent one.