### PR TITLE
Parse: Detect tables in a SELECT INTO clause as DDL tables

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -139,6 +139,10 @@ module PgQuery
               @cte_names.concat(cte_names)
               statements.concat(cte_statements)
             end
+
+            if statement.select_stmt.into_clause
+              from_clause_items << { item: PgQuery::Node.new(range_var: statement.select_stmt.into_clause.rel), type: :ddl }
+            end
           # The following statements modify the contents of a table
           when :insert_stmt, :update_stmt, :delete_stmt
             value = statement.public_send(statement.node)

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1535,7 +1535,7 @@ $BODY$
     expect(query.call_functions).to eq ['unnest', 'json_build_object', 'row_to_json', 'public.my_function']
   end
 
-  it 'finds the table in a SELECT INTO thats being created' do
+  it 'finds the table in a SELECT INTO that is being created' do
     query = described_class.parse(<<-SQL)
     SELECT * INTO films_recent FROM films WHERE date_prod >= '2002-01-01';
     SQL

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -1535,6 +1535,15 @@ $BODY$
     expect(query.call_functions).to eq ['unnest', 'json_build_object', 'row_to_json', 'public.my_function']
   end
 
+  it 'finds the table in a SELECT INTO thats being created' do
+    query = described_class.parse(<<-SQL)
+    SELECT * INTO films_recent FROM films WHERE date_prod >= '2002-01-01';
+    SQL
+    expect(query.tables).to eq(['films', 'films_recent'])
+    expect(query.ddl_tables).to eq(['films_recent'])
+    expect(query.select_tables).to eq(['films'])
+  end
+
   describe 'parsing INSERT' do
     it 'finds the table inserted into' do
       query = described_class.parse(<<-SQL)


### PR DESCRIPTION
Fixes #280