### PR TITLE
Parse: Fix `ALTER INDEX my_index_name` to return non-nil `tables`

### DIFF
--- a/lib/pg_query/parse.rb
+++ b/lib/pg_query/parse.rb
@@ -175,7 +175,12 @@ module PgQuery
             statements << statement.copy_stmt.query
           # The following statement types are DDL (changing table structure)
           when :alter_table_stmt
-            from_clause_items << { item: PgQuery::Node.new(range_var: statement.alter_table_stmt.relation), type: :ddl }
+            case statement.alter_table_stmt.objtype
+            when :OBJECT_INDEX # Index # rubocop:disable Lint/EmptyWhen
+              # ignore `ALTER INDEX index_name`
+            else
+              from_clause_items << { item: PgQuery::Node.new(range_var: statement.alter_table_stmt.relation), type: :ddl }
+            end
           when :create_stmt
             from_clause_items << { item: PgQuery::Node.new(range_var: statement.create_stmt.relation), type: :ddl }
           when :create_table_as_stmt

--- a/spec/lib/parse_spec.rb
+++ b/spec/lib/parse_spec.rb
@@ -164,6 +164,88 @@ describe PgQuery, '.parse' do
     )
   end
 
+  it "parses ALTER VIEW" do
+    query = described_class.parse("ALTER VIEW test SET (security_barrier = TRUE)")
+    expect(query.warnings).to eq []
+    expect(query.tables).to eq ['test']
+    expect(query.ddl_tables).to eq ['test']
+    expect(query.tree.stmts.first).to eq(
+      PgQuery::RawStmt.new(
+        stmt: PgQuery::Node.new(
+          alter_table_stmt: PgQuery::AlterTableStmt.new(
+            relation: PgQuery::RangeVar.new(relname: 'test', inh: true, relpersistence: 'p', location: 11),
+            cmds: [
+              PgQuery::Node.new(
+                alter_table_cmd: PgQuery::AlterTableCmd.new(
+                  subtype: :AT_SetRelOptions,
+                  def: PgQuery::Node.new(
+                    list: PgQuery::List.new(
+                      items: [PgQuery::Node.new(
+                        def_elem: PgQuery::DefElem.new(
+                          defname: "security_barrier",
+                          arg: PgQuery::Node.new(
+                            string: PgQuery::String.new(
+                              sval: "true"
+                            )
+                          ),
+                          defaction: :DEFELEM_UNSPEC,
+                          location: 21
+                        )
+                      )]
+                    )
+                  ),
+                  behavior: :DROP_RESTRICT
+                )
+              )
+            ],
+            objtype: :OBJECT_VIEW
+          )
+        )
+      )
+    )
+  end
+
+  it "parses ALTER INDEX", :aggregate_failures do
+    query = described_class.parse("ALTER INDEX my_index_name SET (fastupdate = on)")
+    expect(query.warnings).to eq []
+    expect(query.tables).to eq []
+    expect(query.ddl_tables).to eq []
+    expect(query.tree.stmts.first).to eq(
+      PgQuery::RawStmt.new(
+        stmt: PgQuery::Node.new(
+          alter_table_stmt: PgQuery::AlterTableStmt.new(
+            relation: PgQuery::RangeVar.new(relname: 'my_index_name', inh: true, relpersistence: 'p', location: 12),
+            cmds: [
+              PgQuery::Node.new(
+                alter_table_cmd: PgQuery::AlterTableCmd.new(
+                  subtype: :AT_SetRelOptions,
+                  def: PgQuery::Node.new(
+                    list: PgQuery::List.new(
+                      items: [PgQuery::Node.new(
+                        def_elem: PgQuery::DefElem.new(
+                          defname: "fastupdate",
+                          arg: PgQuery::Node.new(
+                            string: PgQuery::String.new(
+                              sval: "on"
+                            )
+                          ),
+                          defaction: :DEFELEM_UNSPEC,
+                          location: 31
+                        )
+                      )]
+                    )
+                  ),
+                  behavior: :DROP_RESTRICT
+                )
+              )
+            ],
+            objtype: :OBJECT_INDEX
+          )
+        )
+      )
+    )
+  end
+
   it "parses SET" do
     query = described_class.parse("SET statement_timeout=0")
     expect(query.warnings).to eq []


### PR DESCRIPTION
When parsing `ALTER INDEX index_name SET (fast_update = true);` the `pg_query` wrongly classifies `index_name` as a table name.

Expected output for above is `tables = []`.

This fix is targeted to only ignore `OBJECT_INDEX` to avoid breaking all other patterns.

### References:

- Resolves: https://github.com/pganalyze/pg_query/issues/284
- PostgreSQL documentation: https://www.postgresql.org/docs/current/sql-alterindex.html
- Related to: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/120838#note_1391849262

