### PR TITLE
Restore `pg_query_ruby_freebsd.sym`

### DIFF
--- a/ext/pg_query/pg_query_ruby_freebsd.sym
+++ b/ext/pg_query/pg_query_ruby_freebsd.sym
@@ -1,0 +1,2 @@
+_Init_pg_query
+Init_pg_query


### PR DESCRIPTION
This should fix #291. The restored file was accidentally removed in 5959fd1b