### PR TITLE
Update CI to run against Ruby 3.3, drop Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2'] # 3.3+ is not yet supported by google-protobuf
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3'] # 3.4+ is not yet supported by google-protobuf
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3'] # 3.4+ is not yet supported by google-protobuf
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3'] # 3.4+ is not yet supported by google-protobuf
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       run: bundle exec rake test
     - name: RuboCop
       run: bundle exec rake lint
-      if: matrix.ruby != '3.1' && matrix.ruby != '3.2'
+      if: matrix.ruby != '3.1' && matrix.ruby != '3.2' && matrix.ruby != '3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pg_query (5.1.0)
-      google-protobuf (>= 3.22.3)
+      google-protobuf (>= 3.25.3)
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,7 @@ GEM
     ast (2.4.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    google-protobuf (3.23.4)
+    google-protobuf (3.25.3)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ not correctly handle all CTEs, or rewrite columns with explicit table names.
 
 Currently tested and officially supported Ruby versions:
 
-* CRuby 2.6
 * CRuby 2.7
 * CRuby 3.0
 * CRuby 3.1
 * CRuby 3.2
+* CRuby 3.3
 
 Not supported:
 

--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '0.49.1'
   s.add_development_dependency 'rubocop-rspec', '1.15.1'
   s.add_development_dependency 'simplecov', '~> 0'
-  s.add_dependency 'google-protobuf', '>= 3.22.3'
+  s.add_dependency 'google-protobuf', '>= 3.25.3'
 end


### PR DESCRIPTION
`google-protobuf` [supports Ruby 3.3 in platform-specific versions of 3.25.3](https://rubygems.org/gems/google-protobuf/versions/3.25.3-x86_64-linux)

Some discussion in this thread: https://github.com/protocolbuffers/protobuf/issues/15336#issuecomment-1946383093