### PR TITLE
Fix build with FreeBSD

### DIFF
--- a/ext/pg_query/pg_query_ruby_freebsd.sym
+++ b/ext/pg_query/pg_query_ruby_freebsd.sym
@@ -1,2 +1,1 @@
-_Init_pg_query
 Init_pg_query


### PR DESCRIPTION
This fixes the build for FreBSD 13.2, 13.3, 14.0 and maybe also for 15.
```
linking shared-object pg_query/pg_query.so
ld: error: version script assignment of 'global' to symbol '_Init_pg_query' failed: symbol not defined
cc: error: linker command failed with exit code 1 (use -v to see invocation)
*** Error code 1
```