### PR TITLE
Officially support Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2'] # 3.3+ is not yet supported by google-protobuf
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -21,4 +21,4 @@ jobs:
       run: bundle exec rake test
     - name: RuboCop
       run: bundle exec rake lint
-      if: matrix.ruby != '3.1' && matrix.ruby != '3.2'
+      if: matrix.ruby != '3.1' && matrix.ruby != '3.2'  && matrix.ruby != '3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pg_query (5.1.0)
-      google-protobuf (>= 3.22.3)
+      google-protobuf (~> 4.26.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,8 @@ GEM
     ast (2.4.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    google-protobuf (3.23.4)
+    google-protobuf (4.26.1)
+      rake (>= 13)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Currently tested and officially supported Ruby versions:
 * CRuby 3.0
 * CRuby 3.1
 * CRuby 3.2
+* CRuby 3.3
 
 Not supported:
 

--- a/pg_query.gemspec
+++ b/pg_query.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '0.49.1'
   s.add_development_dependency 'rubocop-rspec', '1.15.1'
   s.add_development_dependency 'simplecov', '~> 0'
-  s.add_dependency 'google-protobuf', '>= 3.22.3'
+  s.add_dependency 'google-protobuf', '~> 4.26.0'
 end


### PR DESCRIPTION
# Description
Officially support Ruby 3.3 🥳.

Ruby 3.3 couldn't be supported straight away because the [google-protobuf](https://rubygems.org/gems/google-protobuf) gem at the locked version didn't support Ruby 3.3.

The version 4.26.0 is the first one that officially supported Ruby 3.3 :)

**Off topic:**
Should we drop support for Ruby 2.6, 2.7 and 3.0 since they are EOL?

**Off topic 2:**
Should we introduce some tool, like Dependabot, to automatically update the dependencies of this project so that they are not left too much behind?
