### PR TITLE
Fix require for ruby 3.4.0-preview1|2

### DIFF
--- a/lib/pg_query.rb
+++ b/lib/pg_query.rb
@@ -4,7 +4,6 @@ require 'pg_query/parse_error'
 require 'pg_query/pg_query_pb'
 require 'pg_query/node'
 
-require 'pg_query/pg_query'
 require 'pg_query/constants'
 require 'pg_query/parse'
 require 'pg_query/treewalker'


### PR DESCRIPTION
This require is causing issues in ruby 3.4.0-preview1 and 2. it does not require a real file

here is the error stack trace ( the error stems from this `  from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/gems/3.4.0+0/bundler/gems/pg_query-f23f1dfe39c6/lib/pg_query.rb:7:in '<main>'`

```
/Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundled_gems.rb:76:in 'Kernel.require': dlsym(0x85a08d50, ruby_abi_version): symbol not found - ruby_abi_version (LoadError)
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel#replace_require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/gems/3.4.0+0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/gems/3.4.0+0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in 'Kernel#require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/gems/3.4.0+0/bundler/gems/pg_query-f23f1dfe39c6/lib/pg_query.rb:7:in '<main>'
        from <internal:/Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
        from <internal:/Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel.replace_require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/gems/3.4.0+0/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in 'Kernel.require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundler/runtime.rb:65:in 'block (2 levels) in Bundler::Runtime#require'
        from <internal:array>:42:in 'Array#each'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundler/runtime.rb:60:in 'block in Bundler::Runtime#require'
        from <internal:array>:42:in 'Array#each'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundler/runtime.rb:52:in 'Bundler::Runtime#require'
        from /Users/chedli/.rbenv/versions/3.4.0-preview2/lib/ruby/3.4.0+0/bundler.rb:213:in 'Bundler.require'
```