### PR TITLE
Add macos-latest to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
+          - 'macos-latest'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This should provide coverage of ARM-based MacOS, e.g. for issues like #327.