### PR TITLE
Fix ABI version error with TruffleRuby on Mac

### DIFF
--- a/ext/pg_query/extconf.rb
+++ b/ext/pg_query/extconf.rb
@@ -43,7 +43,7 @@ end
 SYMFILE = File.join(__dir__, ext_symbols_filename)
 
 if RUBY_PLATFORM =~ /darwin/
-  $DLDFLAGS << " -Wl,-exported_symbols_list #{SYMFILE}" unless defined?(::Rubinius)
+  $DLDFLAGS << " -Wl,-exported_symbols_list #{SYMFILE}" unless %w(rbx truffleruby).include?(RUBY_ENGINE)
 elsif RUBY_PLATFORM !~ /cygwin|mswin|mingw|bccwin|wince|emx/
   $DLDFLAGS << " -Wl,--retain-symbols-file=#{SYMFILE}"
 end


### PR DESCRIPTION
Fixes

```text
LoadError:
  The native extension at /path/to/pg_query/lib/pg_query/pg_query.bundle has a different ABI version: nil than the running TruffleRuby: "3.3.5.24.2.0.1"
```

(and the test suite passes 🎉 )