### PR TITLE
Add PgQuery.summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* ...
+* Add `PgQuery.summary` method
+  - This uses the new `pg_query_summary` C function that significantly improves performance when
+    you need metadata (like a list of referenced tables) but don't need the full parse tree.
 
 ## 6.2.2     2026-01-26
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ PgQuery.parse("SELECT $1 FROM x WHERE x.y = $2 AND z = $3").filter_columns
 => [["x", "y"], [nil, "z"]]
 ```
 
+### Summarizing a query
+
+`PgQuery.summary` returns the same kind of information as `PgQuery.parse` (tables, functions,
+CTE names, aliases, filter columns and statement types), but gathers it inside the native C
+library instead of sending the full parse tree over protobuf, which is significantly faster
+for large queries.
+
+```ruby
+summary = PgQuery.summary("SELECT $1 FROM x JOIN y USING (id) WHERE z = $2")
+
+summary.tables
+=> ["x", "y"]
+
+summary.statement_types
+=> ["SelectStmt"]
+
+# Like PgQuery.parse(query).truncate(40), except the limit has to be passed in up front
+PgQuery.summary("SELECT a, b, c, d, e, f FROM xyz WHERE a = b", truncate_limit: 40).truncated_query
+
+=> "SELECT ... FROM xyz WHERE a = b"
+```
+
+See the comments on `PgQuery::SummaryParserResult` for how it differs from `PgQuery::ParserResult`.
+
 ### Fingerprinting a query
 
 ```ruby

--- a/ext/pg_query/pg_query_ruby.c
+++ b/ext/pg_query/pg_query_ruby.c
@@ -8,6 +8,7 @@ void raise_ruby_normalize_error(PgQueryNormalizeResult result);
 void raise_ruby_fingerprint_error(PgQueryFingerprintResult result);
 void raise_ruby_scan_error(PgQueryScanResult result);
 void raise_ruby_split_error(PgQuerySplitResult result);
+void raise_ruby_summary_error(PgQuerySummaryParseResult result);
 
 VALUE pg_query_ruby_parse_protobuf(VALUE self, VALUE input);
 VALUE pg_query_ruby_deparse_protobuf(VALUE self, VALUE input);
@@ -17,6 +18,7 @@ VALUE pg_query_ruby_normalize(VALUE self, VALUE input);
 VALUE pg_query_ruby_fingerprint(VALUE self, VALUE input);
 VALUE pg_query_ruby_scan(VALUE self, VALUE input);
 VALUE pg_query_ruby_split_with_parser(VALUE self, VALUE input);
+VALUE pg_query_ruby_summary(VALUE self, VALUE input, VALUE truncate_limit);
 VALUE pg_query_ruby_hash_xxh3_64(VALUE self, VALUE input, VALUE seed);
 
 __attribute__((visibility ("default"))) void Init_pg_query(void)
@@ -33,6 +35,7 @@ __attribute__((visibility ("default"))) void Init_pg_query(void)
 	rb_define_singleton_method(cPgQuery, "fingerprint", pg_query_ruby_fingerprint, 1);
 	rb_define_singleton_method(cPgQuery, "_raw_scan", pg_query_ruby_scan, 1);
 	rb_define_singleton_method(cPgQuery, "_raw_split_with_parser", pg_query_ruby_split_with_parser, 1);
+	rb_define_singleton_method(cPgQuery, "_raw_summary", pg_query_ruby_summary, 2);
 	rb_define_singleton_method(cPgQuery, "hash_xxh3_64", pg_query_ruby_hash_xxh3_64, 2);
 	rb_define_const(cPgQuery, "PG_VERSION", rb_str_new2(PG_VERSION));
 	rb_define_const(cPgQuery, "PG_MAJORVERSION", rb_str_new2(PG_MAJORVERSION));
@@ -163,6 +166,24 @@ void raise_ruby_split_error(PgQuerySplitResult result)
 	pg_query_free_split_result(result);
 
 	rb_exc_raise(rb_class_new_instance(4, args, cSplitError));
+}
+
+void raise_ruby_summary_error(PgQuerySummaryParseResult result)
+{
+	VALUE cPgQuery, cParseError;
+	VALUE args[4];
+
+	cPgQuery    = rb_const_get(rb_cObject, rb_intern("PgQuery"));
+	cParseError = rb_const_get_at(cPgQuery, rb_intern("ParseError"));
+
+	args[0] = rb_str_new2(result.error->message);
+	args[1] = rb_str_new2(result.error->filename);
+	args[2] = INT2NUM(result.error->lineno);
+	args[3] = INT2NUM(result.error->cursorpos);
+
+	pg_query_free_summary_parse_result(result);
+
+	rb_exc_raise(rb_class_new_instance(4, args, cParseError));
 }
 
 VALUE pg_query_ruby_parse_protobuf(VALUE self, VALUE input)
@@ -362,6 +383,26 @@ VALUE pg_query_ruby_split_with_parser(VALUE self, VALUE input)
 	rb_ary_push(output, rb_str_new2(result.stderr_buffer));
 
 	pg_query_free_split_result(result);
+
+	return output;
+}
+
+VALUE pg_query_ruby_summary(VALUE self, VALUE input, VALUE truncate_limit)
+{
+	Check_Type(input, T_STRING);
+	Check_Type(truncate_limit, T_FIXNUM);
+
+	VALUE output;
+	PgQuerySummaryParseResult result = pg_query_summary(StringValueCStr(input), 0, NUM2INT(truncate_limit));
+
+	if (result.error) raise_ruby_summary_error(result);
+
+	output = rb_ary_new();
+
+	rb_ary_push(output, rb_str_new(result.summary.data, result.summary.len));
+	rb_ary_push(output, rb_str_new2(result.stderr_buffer));
+
+	pg_query_free_summary_parse_result(result);
 
 	return output;
 }

--- a/lib/pg_query.rb
+++ b/lib/pg_query.rb
@@ -17,3 +17,4 @@ require 'pg_query/truncate'
 
 require 'pg_query/scan'
 require 'pg_query/split'
+require 'pg_query/summary'

--- a/lib/pg_query/summary.rb
+++ b/lib/pg_query/summary.rb
@@ -1,0 +1,145 @@
+module PgQuery
+  # Parses the given SQL statement and returns a summary of it.
+  #
+  # It is possible to gather the same information using PgQuery.parse and
+  # walking the parse tree, but summary does this work in C, and only sends
+  # the summarized information over protobuf. Avoiding sending the full parse
+  # tree over protobuf can be significantly faster for large queries.
+  #
+  # Note that truncation happens on the C side, and so the maximum length has
+  # to be passed in ahead of time. summary(query, truncate_limit: 100).truncated_query
+  # is the equivalent of parse(query).truncate(100).
+  def self.summary(query, truncate_limit: -1)
+    result, stderr = _raw_summary(query, truncate_limit)
+
+    begin
+      result = PgQuery::SummaryResult.decode(result)
+    rescue Google::Protobuf::ParseError => e
+      raise PgQuery::ParseError.new(format('Failed to parse summary: %s', e.message), __FILE__, __LINE__, -1)
+    end
+
+    warnings = []
+    stderr.each_line do |line|
+      next unless line[/^WARNING/]
+      warnings << line.strip
+    end
+
+    PgQuery::SummaryParserResult.new(query, result, warnings, truncate_limit)
+  end
+
+  # Result of PgQuery.summary.
+  #
+  # Where possible this is API compatible with ParserResult, with these caveats:
+  #
+  # - tables_with_details omits the location, inh and relpersistence values that
+  #   ParserResult reports, since the summary does not carry them
+  # - filter_columns only covers the WHERE clause of SELECT statements, so unlike
+  #   ParserResult#filter_columns it does not include JOIN conditions, or the WHERE
+  #   clause of UPDATE/DELETE statements
+  # - functions_with_details additionally returns the schema name and the bare
+  #   function name, which ParserResult does not provide
+  # - statement_types has no ParserResult equivalent, returns the statement types of
+  #   the query, e.g. ["SelectStmt"]
+  # - truncated_query is offered instead of ParserResult#truncate(max_length), since
+  #   truncation has already happened when the result is returned - it returns nil if
+  #   no truncate_limit was passed to PgQuery.summary
+  #
+  # The underlying protobuf message is available through #protobuf.
+  class SummaryParserResult
+    attr_reader :query, :protobuf, :warnings
+
+    def initialize(query, protobuf, warnings = [], truncate_limit = -1)
+      @query = query
+      @protobuf = protobuf
+      @warnings = warnings
+      @truncate_limit = truncate_limit
+    end
+
+    def tables
+      tables_with_details.map { |t| t[:name] }.uniq
+    end
+
+    def select_tables
+      tables_with_details.select { |t| t[:type] == :select }.map { |t| t[:name] }.uniq
+    end
+
+    def dml_tables
+      tables_with_details.select { |t| t[:type] == :dml }.map { |t| t[:name] }.uniq
+    end
+
+    def ddl_tables
+      tables_with_details.select { |t| t[:type] == :ddl }.map { |t| t[:name] }.uniq
+    end
+
+    def functions
+      functions_with_details.map { |f| f[:function] }.uniq
+    end
+
+    def ddl_functions
+      functions_with_details.select { |f| f[:type] == :ddl }.map { |f| f[:function] }.uniq
+    end
+
+    def call_functions
+      functions_with_details.select { |f| f[:type] == :call }.map { |f| f[:function] }.uniq
+    end
+
+    def cte_names
+      @cte_names ||= @protobuf.cte_names.to_a.uniq
+    end
+
+    def aliases
+      @aliases ||= @protobuf.aliases.to_h
+    end
+
+    def tables_with_details
+      @tables_with_details ||= @protobuf.tables.map do |table|
+        {
+          name: table.name,
+          type: context_to_type(table.context),
+          schemaname: (table.schema_name unless table.schema_name.empty?),
+          relname: table.table_name
+        }
+      end.uniq
+    end
+
+    def functions_with_details
+      @functions_with_details ||= @protobuf.functions.map do |function|
+        {
+          function: function.name,
+          type: context_to_type(function.context),
+          schemaname: (function.schema_name unless function.schema_name.empty?),
+          funcname: function.function_name
+        }
+      end.uniq
+    end
+
+    def filter_columns
+      @filter_columns ||= @protobuf.filter_columns.map do |filter_column|
+        table = [filter_column.schema_name, filter_column.table_name].reject(&:empty?).join('.')
+        table = nil if table.empty?
+        [aliases[table] || table, filter_column.column]
+      end.uniq
+    end
+
+    def statement_types
+      @statement_types ||= @protobuf.statement_types.to_a
+    end
+
+    def truncated_query
+      @protobuf.truncated_query unless @truncate_limit == -1
+    end
+
+    private
+
+    CONTEXT_TYPES = {
+      Select: :select,
+      DML: :dml,
+      DDL: :ddl,
+      Call: :call
+    }.freeze
+
+    def context_to_type(context)
+      CONTEXT_TYPES[context]
+    end
+  end
+end

--- a/spec/lib/summary_spec.rb
+++ b/spec/lib/summary_spec.rb
@@ -1,0 +1,327 @@
+require 'spec_helper'
+
+describe PgQuery, '.summary' do
+  it 'summarizes a simple query' do
+    summary = described_class.summary('SELECT * FROM test WHERE a = 1')
+
+    expect(summary.query).to eq 'SELECT * FROM test WHERE a = 1'
+    expect(summary.warnings).to eq []
+    expect(summary.tables).to eq ['test']
+    expect(summary.select_tables).to eq ['test']
+    expect(summary.dml_tables).to eq []
+    expect(summary.ddl_tables).to eq []
+    expect(summary.aliases).to eq({})
+    expect(summary.cte_names).to eq []
+    expect(summary.functions).to eq []
+    expect(summary.filter_columns).to eq [[nil, 'a']]
+    expect(summary.statement_types).to eq ['SelectStmt']
+    expect(summary.truncated_query).to be_nil
+  end
+
+  it 'summarizes an empty query' do
+    summary = described_class.summary('-- nothing')
+
+    expect(summary.warnings).to eq []
+    expect(summary.tables).to eq []
+    expect(summary.aliases).to eq({})
+    expect(summary.cte_names).to eq []
+    expect(summary.functions).to eq []
+    expect(summary.filter_columns).to eq []
+    expect(summary.statement_types).to eq []
+  end
+
+  it 'returns the raw protobuf result' do
+    summary = described_class.summary('SELECT * FROM test')
+
+    expect(summary.protobuf).to be_a PgQuery::SummaryResult
+    expect(summary.protobuf.tables.first).to eq(
+      PgQuery::SummaryResult::Table.new(name: 'test', table_name: 'test', context: :Select)
+    )
+  end
+
+  it 'finds aliases' do
+    summary = described_class.summary('SELECT * FROM test AS x WHERE a = 1')
+
+    expect(summary.tables).to eq ['test']
+    expect(summary.aliases).to eq('x' => 'test')
+  end
+
+  it 'finds tables in nested sub-selects' do
+    summary = described_class.summary('SELECT * FROM test WHERE col1 = (SELECT col2 FROM test2 WHERE col3 = 123)')
+
+    expect(summary.tables).to match_array %w[test test2]
+    expect(summary.filter_columns).to match_array [[nil, 'col1'], [nil, 'col3']]
+  end
+
+  it 'finds tables in joins' do
+    summary = described_class.summary('SELECT * FROM t0 JOIN t1 ON (t0.id = t1.id)')
+
+    expect(summary.tables).to match_array %w[t0 t1]
+  end
+
+  it 'handles deeply nested queries that exceed the protobuf recursion limit of .parse' do
+    query = 'SELECT * FROM t0 ' + (1..600).map { |i| "JOIN t#{i} ON (1)" }.join(' ')
+
+    expect { described_class.parse(query) }.to raise_error(PgQuery::ParseError, /Failed to parse tree/)
+
+    summary = described_class.summary(query)
+    expect(summary.tables.size).to eq 601
+    expect(summary.statement_types).to eq ['SelectStmt']
+  end
+
+  it 'keeps track of schema names' do
+    summary = described_class.summary('SELECT * FROM public.test')
+
+    expect(summary.tables).to eq ['public.test']
+    expect(summary.tables_with_details).to eq [
+      { name: 'public.test', type: :select, schemaname: 'public', relname: 'test' }
+    ]
+  end
+
+  it 'excludes CTE names from tables' do
+    summary = described_class.summary('WITH a AS (SELECT * FROM x) SELECT * FROM a')
+
+    expect(summary.tables).to eq ['x']
+    expect(summary.cte_names).to eq ['a']
+  end
+
+  it 'finds tables modified by DML statements' do
+    summary = described_class.summary('INSERT INTO x (a) SELECT a FROM y')
+
+    expect(summary.dml_tables).to eq ['x']
+    expect(summary.select_tables).to eq ['y']
+    expect(summary.statement_types).to eq ['InsertStmt', 'SelectStmt']
+  end
+
+  # Note that the source table (src) is not reported, since the C implementation only
+  # looks at the target relation of a MERGE. PgQuery.parse reports neither of the two.
+  it 'finds the target table of MERGE statements' do
+    summary = described_class.summary('MERGE INTO tgt USING src ON tgt.id = src.id WHEN MATCHED THEN UPDATE SET a = src.a')
+
+    expect(summary.tables).to eq ['tgt']
+    expect(summary.dml_tables).to eq ['tgt']
+    expect(summary.statement_types).to eq ['MergeStmt']
+  end
+
+  it 'finds tables modified by DDL statements' do
+    summary = described_class.summary('ALTER TABLE test ADD PRIMARY KEY (gid)')
+
+    expect(summary.ddl_tables).to eq ['test']
+    expect(summary.tables_with_details).to eq [
+      { name: 'test', type: :ddl, schemaname: nil, relname: 'test' }
+    ]
+    expect(summary.statement_types).to eq ['AlterTableStmt']
+  end
+
+  it 'finds called functions' do
+    summary = described_class.summary('SELECT foo.testfunc(1), lower(name) FROM x')
+
+    expect(summary.functions).to match_array ['foo.testfunc', 'lower']
+    expect(summary.call_functions).to match_array ['foo.testfunc', 'lower']
+    expect(summary.ddl_functions).to eq []
+    expect(summary.functions_with_details).to match_array [
+      { function: 'foo.testfunc', type: :call, schemaname: 'foo', funcname: 'testfunc' },
+      { function: 'lower', type: :call, schemaname: nil, funcname: 'lower' }
+    ]
+  end
+
+  it 'finds functions defined by DDL statements' do
+    summary = described_class.summary('CREATE FUNCTION foo.testfunc(x int) RETURNS int AS $$ SELECT x $$ LANGUAGE SQL')
+
+    expect(summary.functions).to eq ['foo.testfunc']
+    expect(summary.ddl_functions).to eq ['foo.testfunc']
+    expect(summary.call_functions).to eq []
+  end
+
+  it 'summarizes multi-statement queries' do
+    summary = described_class.summary('SELECT * FROM x; INSERT INTO y (a) VALUES (1); CREATE TABLE z (id int)')
+
+    expect(summary.select_tables).to eq ['x']
+    expect(summary.dml_tables).to eq ['y']
+    expect(summary.ddl_tables).to eq ['z']
+    expect(summary.statement_types).to eq ['SelectStmt', 'InsertStmt', 'CreateStmt']
+  end
+
+  it 'raises a parse error for invalid queries' do
+    expect { described_class.summary('SELECT \'ERR') }.to raise_error(PgQuery::ParseError, /unterminated quoted string/)
+    expect { described_class.summary('CREATE RANDOM ix_test ON contacts.person') }.to raise_error(PgQuery::ParseError) do |error|
+      expect(error.message).to include 'syntax error at or near "RANDOM"'
+      expect(error.location).to eq 8
+    end
+  end
+
+  describe 'truncation' do
+    it 'does not truncate by default' do
+      expect(described_class.summary('SELECT a, b, c, d, e, f FROM xyz WHERE a = b').truncated_query).to be_nil
+    end
+
+    it 'omits the target list' do
+      query = 'SELECT a, b, c, d, e, f FROM xyz WHERE a = b'
+      expect(described_class.summary(query, truncate_limit: 40).truncated_query).to eq 'SELECT ... FROM xyz WHERE a = b'
+    end
+
+    it 'omits part of CTEs' do
+      query = 'WITH x AS (SELECT * FROM y) SELECT * FROM x'
+      expect(described_class.summary(query, truncate_limit: 40).truncated_query).to eq 'WITH x AS (...) SELECT * FROM x'
+    end
+
+    it 'omits the where clause' do
+      query = 'SELECT * FROM z WHERE a = b AND x = y'
+      expect(described_class.summary(query, truncate_limit: 30).truncated_query).to eq 'SELECT * FROM z WHERE ...'
+    end
+
+    it 'performs a simple truncation if necessary' do
+      expect(described_class.summary('SELECT * FROM t', truncate_limit: 10).truncated_query).to eq 'SELECT ...'
+    end
+
+    it 'returns the deparsed query if it is short enough' do
+      expect(described_class.summary('SELECT * FROM t', truncate_limit: 100).truncated_query).to eq 'SELECT * FROM t'
+    end
+
+    it 'returns an empty string for a query that deparses to nothing' do
+      expect(described_class.summary('-- nothing', truncate_limit: 10).truncated_query).to eq ''
+    end
+
+    context 'with multi-byte characters' do
+      # The CTE name mixes kanji and katakana, both of which are three bytes per
+      # character in UTF-8, so that a cut based on byte offsets lands in the middle
+      # of a character.
+      let(:query) { 'WITH "都道府県別ストア別月次売上集計" AS (SELECT) SELECT w' }
+
+      it 'never truncates in the middle of a character' do
+        (10..45).each do |limit|
+          truncated = described_class.summary(query, truncate_limit: limit).truncated_query
+
+          expect(truncated.encoding).to eq Encoding::UTF_8
+          expect(truncated).to be_valid_encoding
+          expect(truncated.length).to be <= limit
+        end
+      end
+
+      it 'truncates the query' do
+        expect(described_class.summary(query, truncate_limit: 21).truncated_query).to eq 'WITH "都道府県別ストア別月次売...'
+        expect(described_class.summary(query, truncate_limit: 40).truncated_query).to eq 'WITH "都道府県別ストア別月次売上集計" AS (...) SELECT w'
+      end
+
+      # The C implementation checks whether the query still needs truncating based on its
+      # length in bytes, but performs the final cut based on its length in characters, so
+      # the result can be shorter than the one PgQuery.parse(...).truncate returns.
+      it 'is a known difference to .parse for limits between the byte and character length' do
+        expect(described_class.summary(query, truncate_limit: 22).truncated_query).to eq 'WITH "都道府県別ストア別月次売...'
+        expect(described_class.parse(query).truncate(22)).to eq 'WITH "都道府県別ストア別月次売上...'
+      end
+    end
+  end
+
+  describe 'filter columns' do
+    def filter_columns(query)
+      described_class.summary(query).filter_columns
+    end
+
+    it 'finds unqualified names' do
+      expect(filter_columns('SELECT * FROM x WHERE y = $1 AND z = 1')).to eq [[nil, 'y'], [nil, 'z']]
+    end
+
+    it 'finds qualified names' do
+      expect(filter_columns('SELECT * FROM x WHERE x.y = $1 AND x.z = 1')).to eq [['x', 'y'], ['x', 'z']]
+    end
+
+    it 'resolves aliases to the table name' do
+      expect(filter_columns('SELECT * FROM x AS a WHERE a.y = $1')).to eq [['x', 'y']]
+    end
+
+    it 'traverses into CTEs' do
+      query = 'WITH a AS (SELECT * FROM x WHERE x.y = $1 AND x.z = 1) SELECT * FROM a WHERE b = 5'
+      expect(filter_columns(query)).to match_array [['x', 'y'], ['x', 'z'], [nil, 'b']]
+    end
+
+    it 'recognizes boolean tests' do
+      expect(filter_columns('SELECT * FROM x WHERE x.y IS TRUE AND x.z IS NOT FALSE')).to eq [['x', 'y'], ['x', 'z']]
+    end
+
+    it 'recognizes null tests' do
+      expect(filter_columns('SELECT * FROM x WHERE x.y IS NULL AND x.z IS NOT NULL')).to eq [['x', 'y'], ['x', 'z']]
+    end
+
+    it 'finds COALESCE argument names' do
+      expect(filter_columns('SELECT * FROM x WHERE x.y = COALESCE(z.a, z.b)')).to eq [['x', 'y'], ['z', 'a'], ['z', 'b']]
+    end
+
+    it 'ignores target list columns' do
+      expect(filter_columns('SELECT a, y, z FROM x WHERE x.y = $1')).to eq [['x', 'y']]
+    end
+
+    it 'ignores ORDER BY columns' do
+      expect(filter_columns('SELECT * FROM x WHERE x.y = $1 ORDER BY a, b')).to eq [['x', 'y']]
+    end
+
+    ['UNION', 'UNION ALL', 'EXCEPT', 'EXCEPT ALL', 'INTERSECT', 'INTERSECT ALL'].each do |combiner|
+      it "finds unqualified names in #{combiner} query" do
+        query = "SELECT * FROM x where y = $1 #{combiner} SELECT * FROM x where z = $2"
+        expect(filter_columns(query)).to eq [[nil, 'y'], [nil, 'z']]
+      end
+    end
+
+    # These are known differences to PgQuery.parse(...).filter_columns, caused by the
+    # C implementation only collecting filter columns from SELECT WHERE clauses.
+    context 'known differences to .parse' do
+      it 'does not include JOIN conditions' do
+        query = 'SELECT * FROM x JOIN y ON (x.id = y.x_id)'
+        expect(filter_columns(query)).to eq []
+        expect(described_class.parse(query).filter_columns).to match_array [['x', 'id'], ['y', 'x_id']]
+      end
+
+      it 'does not include the WHERE clause of UPDATE statements' do
+        query = 'UPDATE x SET a = 1 WHERE x.b = $1'
+        expect(filter_columns(query)).to eq []
+        expect(described_class.parse(query).filter_columns).to eq [['x', 'b']]
+      end
+
+      it 'does not include the WHERE clause of DELETE statements' do
+        query = 'DELETE FROM x WHERE x.b = $1'
+        expect(filter_columns(query)).to eq []
+        expect(described_class.parse(query).filter_columns).to eq [['x', 'b']]
+      end
+
+      it 'includes the WHERE clause of a SELECT inside an INSERT' do
+        query = 'INSERT INTO x (a) SELECT a FROM y WHERE y.b = $1'
+        expect(filter_columns(query)).to eq [['y', 'b']]
+        expect(described_class.parse(query).filter_columns).to eq []
+      end
+    end
+  end
+
+  describe 'compatibility with .parse' do
+    queries = [
+      'SELECT * FROM test AS x WHERE a = 1',
+      'SELECT memory_total_bytes, (memory_swap_total_bytes - memory_swap_free_bytes) AS swap, ' \
+      'date_part($0, s.collected_at) AS collected_at FROM snapshots s JOIN system_snapshots ON (snapshot_id = s.id) ' \
+      'WHERE s.database_id = $0 AND s.collected_at BETWEEN $0 AND $0 ORDER BY collected_at',
+      'WITH a AS (SELECT * FROM x WHERE x.y = $1) SELECT * FROM a WHERE b = 5',
+      'INSERT INTO x (a) SELECT a FROM y WHERE y.b = $1',
+      'UPDATE x SET a = 1 WHERE x.b = $1',
+      'DELETE FROM x WHERE x.b = $1',
+      'CREATE TABLE test (id int)',
+      'DROP TABLE test'
+    ]
+
+    # Note that filter_columns is intentionally not compared here, see the
+    # "known differences to .parse" tests above.
+    queries.each do |query|
+      it "matches .parse for #{query}" do
+        summary = described_class.summary(query)
+        parsed = described_class.parse(query)
+
+        expect(summary.tables).to match_array parsed.tables
+        expect(summary.select_tables).to match_array parsed.select_tables
+        expect(summary.dml_tables).to match_array parsed.dml_tables
+        expect(summary.ddl_tables).to match_array parsed.ddl_tables
+        expect(summary.functions).to match_array parsed.functions
+        expect(summary.call_functions).to match_array parsed.call_functions
+        expect(summary.ddl_functions).to match_array parsed.ddl_functions
+        expect(summary.cte_names).to match_array parsed.cte_names
+        expect(summary.aliases).to eq parsed.aliases
+      end
+    end
+  end
+end


### PR DESCRIPTION
This uses the `pg_query_summary` C function to gather query metadata without sending the full parse tree over protobuf, which is significantly faster for large queries.

See https://github.com/pganalyze/pg_query.rs/pull/62 for the Rust side implementation.