### PR TITLE
Add Ruby 4.0 support, drop 3.0 and 3.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,16 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.0'
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,9 +11,9 @@ GEM
     bigdecimal (4.1.2)
     diff-lcs (1.5.1)
     docile (1.4.1)
-    google-protobuf (4.33.6)
+    google-protobuf (4.36.0)
       bigdecimal
-      rake (>= 13)
+      rake (~> 13.3)
     json (2.19.9)
     language_server-protocol (3.17.0.4)
     parallel (1.26.3)
@@ -22,7 +22,7 @@ GEM
       racc
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.4.2)
     rake-compiler (0.9.9)
       rake
     regexp_parser (2.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    bigdecimal (3.1.9)
+    bigdecimal (4.1.2)
     diff-lcs (1.5.1)
     docile (1.4.1)
-    google-protobuf (4.30.2)
+    google-protobuf (4.33.6)
       bigdecimal
       rake (>= 13)
     json (2.19.9)
@@ -62,7 +62,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -202,11 +202,10 @@ not correctly handle all CTEs, or rewrite columns with explicit table names.
 
 Currently tested and officially supported Ruby versions:
 
-* CRuby 3.0
-* CRuby 3.1
 * CRuby 3.2
 * CRuby 3.3
 * CRuby 3.4
+* CRuby 4.0
 
 Not supported:
 


### PR DESCRIPTION
Add Ruby 4.0 support, and drop 3.0 and 3.1 support. I would like to merge this before the next release: https://github.com/pganalyze/pg_query/pull/351

Also handling https://github.com/pganalyze/pg_query/pull/353